### PR TITLE
Fix behaviour when colored light is applied

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -151,6 +151,13 @@ float4 frag_forward(v2f i) : SV_TARGET
     half3 lighting = directLighting + indirectLighting;
     lighting = lerp(lighting, max(0.001, max(lighting.x, max(lighting.y, lighting.z))), _LightColorAttenuation); // color atten
     
+#ifdef POINT
+    lighting *= tex2D(_LightTexture0, dot(lightCoord, lightCoord).rr).r;
+#endif
+#ifdef SPOT
+    lighting *= (lightCoord.z > 0) * UnitySpotCookie(lightCoord) * UnitySpotAttenuate(lightCoord.xyz);
+#endif
+
     // color lerp
     half4 shade = _ShadeColor * tex2D(_ShadeTexture, mainUv);
     half4 lit = _Color * mainTex;

--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -146,7 +146,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     lightIntensity = smoothstep(_ShadeShift, _ShadeShift + (1.0 - _ShadeToony), lightIntensity); // shade & tooned
 
     // lighting with color
-    half3 directLighting = lightIntensity * _LightColor0.rgb; // direct
+    half3 directLighting = _LightColor0.rgb; // direct
     half3 indirectLighting = _IndirectLightIntensity * ShadeSH9(half4(worldNormal, 1)); // ambient
     half3 lighting = directLighting + indirectLighting;
     lighting = lerp(lighting, max(0.001, max(lighting.x, max(lighting.y, lighting.z))), _LightColorAttenuation); // color atten
@@ -154,11 +154,9 @@ float4 frag_forward(v2f i) : SV_TARGET
     // color lerp
     half4 shade = _ShadeColor * tex2D(_ShadeTexture, mainUv);
     half4 lit = _Color * mainTex;
-#ifdef MTOON_FORWARD_ADD
-    half3 col = lerp(half3(0,0,0), lit.rgb, lighting);
-#else
-    half3 col = lerp(shade.rgb, lit.rgb, lighting);
-#endif
+    
+    half3 col = lerp(shade.rgb, lit.rgb, lightIntensity);
+    col *= lighting;
 
     // energy conservation
     half3 lightPower = _LightColor0.rgb + ShadeSH9(half4(0, 1, 0, 1));

--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -161,14 +161,8 @@ float4 frag_forward(v2f i) : SV_TARGET
     // color lerp
     half4 shade = _ShadeColor * tex2D(_ShadeTexture, mainUv);
     half4 lit = _Color * mainTex;
-    
     half3 col = lerp(shade.rgb, lit.rgb, lightIntensity);
     col *= lighting;
-
-    // energy conservation
-    half3 lightPower = _LightColor0.rgb + ShadeSH9(half4(0, 1, 0, 1));
-    half lightPowerV = max(0.001, max(lightPower.x, max(lightPower.y, lightPower.z)));
-    col *= saturate(lightPowerV);
 
     // additive matcap
 #ifdef MTOON_FORWARD_ADD


### PR DESCRIPTION
# 変更内容
より他のUnity Built-inなマテリアルと調和するように、Lightの挙動を変更しました。

# 主な違い
## マテリアルの設定
![snapcrab_noname_2018-12-28_14-56-30_no-00](https://user-images.githubusercontent.com/3889597/50504408-d674a000-0ab0-11e9-9d26-c9479849836e.png)

## DirectionalLightiの場合
### 従来の挙動
ライトは赤色だが、赤以外の色が出ている

![snapcrab_noname_2018-12-28_15-7-45_no-00](https://user-images.githubusercontent.com/3889597/50504645-5c451b00-0ab2-11e9-84d3-01bf173618fb.png)

### このPRでの挙動
ライトで与えられた色以外の色が出ていない
![snapcrab_noname_2018-12-28_15-7-37_no-00](https://user-images.githubusercontent.com/3889597/50504650-62d39280-0ab2-11e9-88b1-806c028d9500.png)

## PointLightの場合

### 従来の挙動
Shade Colorに色が設定されているが、陰の部分に黒色が出ている

![snapcrab_noname_2018-12-28_15-8-40_no-00](https://user-images.githubusercontent.com/3889597/50504663-7848bc80-0ab2-11e9-9d1c-4eb556b74dec.png)

### このPRでの挙動
Shade Colorとして指定された色が陰色として出ている
![snapcrab_noname_2018-12-28_15-9-9_no-00](https://user-images.githubusercontent.com/3889597/50504669-8991c900-0ab2-11e9-9f91-44444ac86291.png)
