### PR TITLE
Update LitShadeRate debug mode

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -205,7 +205,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     #ifdef MTOON_FORWARD_ADD
         return float4(0, 0, 0, 0);
     #else
-        return float4(lighting, alpha);
+        return float4(lightIntensity * lighting, alpha);
     #endif
 #endif
 


### PR DESCRIPTION
LitShadeRateデバッグモードが、最近のアップデートに伴い以前通りに動かなくなっていたため、
これを修正しました。