### PR TITLE
Fix 2019.1 compatibility issue

### DIFF
--- a/MToon/Resources/Shaders/MToon.shader
+++ b/MToon/Resources/Shaders/MToon.shader
@@ -130,8 +130,30 @@ Shader "VRM/MToon"
             ENDCG
         }
         
-        // Cast transparent shadow
-        UsePass "Standard/SHADOWCASTER"
+        // ------------------------------------------------------------------
+        //  Shadow rendering pass
+        Pass {
+            Name "ShadowCaster"
+            Tags { "LightMode" = "ShadowCaster" }
+
+            ZWrite On ZTest LEqual
+
+            CGPROGRAM
+            #pragma target 2.0
+
+            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature _METALLICGLOSSMAP
+            #pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma skip_variants SHADOWS_SOFT
+            #pragma multi_compile_shadowcaster
+
+            #pragma vertex vertShadowCaster
+            #pragma fragment fragShadowCaster
+
+            #include "UnityStandardShadow.cginc"
+
+            ENDCG
+        }
     }
     
     Fallback "Unlit/Texture"


### PR DESCRIPTION
Referred from https://github.com/vrm-c/UniVRM/issues/237

After a deeper dig, I found out the problem is caused by the line below.
`UsePass "Standard/SHADOWCASTER"`
The problem is introduced by the new modification on Standard.shader. It uses shader_feature_local instead of shader_feature.
The shader_feature_local will just make the keywords for multi_compile and shader_feature not working anymore.
And also, the problem can't be reverted. Once you compiled the shader with shader_feature_local. Even you remove the lines.
The keyword will still not work.

The temp workaround is to delete the shader. And use the code below for a temp fix. I'll still wait for the replies from official and give more updates here.
```
			Pass {
				Name "ShadowCaster"
				Tags { "LightMode" = "ShadowCaster" }

				ZWrite On ZTest LEqual

				CGPROGRAM
				#pragma target 3.0

				// -------------------------------------


				#pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
				#pragma shader_feature _METALLICGLOSSMAP
				#pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
				#pragma shader_feature _PARALLAXMAP
				#pragma multi_compile_shadowcaster
				#pragma multi_compile_instancing
				// Uncomment the following line to enable dithering LOD crossfade. Note: there are more in the file to uncomment for other passes.
				//#pragma multi_compile _ LOD_FADE_CROSSFADE

				#pragma vertex vertShadowCaster
				#pragma fragment fragShadowCaster

				#include "UnityStandardShadow.cginc"

				ENDCG
			}
```