### PR TITLE
Darken if transparent material.

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -187,6 +187,9 @@ float4 frag_forward(v2f i) : SV_TARGET
     half3 lighting = _LightColor0.rgb;
     lighting = lerp(lighting, max(0.001, max(lighting.x, max(lighting.y, lighting.z))), _LightColorAttenuation); // color atten
 #ifdef MTOON_FORWARD_ADD
+#ifdef _ALPHABLEND_ON
+    lighting *= step(0, dotNL); // darken if transparent. Because transparent material can't receive shadowAttenuation.
+#endif
     lighting *= dotNL * 0.5 + 0.5; // darken by using half lambert
     lighting *= shadowAttenuation; // darken if receiving shadow
 #else


### PR DESCRIPTION
`Transparent` queue material can't receive shadows in Unity, so darken transparent material if `dot(N, L) < 0` .