### PR TITLE
Remove uv offset texture implementation.

### DIFF
--- a/MToon/Editor/MToonInspector.cs
+++ b/MToon/Editor/MToonInspector.cs
@@ -46,8 +46,6 @@ namespace MToon
         private MaterialProperty _rimLightingMix;
         private MaterialProperty _rimFresnelPower;
         private MaterialProperty _rimLift;
-        private MaterialProperty _uvOffsetNormalTexture;
-        private MaterialProperty _uvOffsetNormalScale;
         private MaterialProperty _uvAnimMaskTexture;
         private MaterialProperty _uvAnimScrollX;
         private MaterialProperty _uvAnimScrollY;
@@ -90,8 +88,6 @@ namespace MToon
             _outlineScaledMaxDistance = FindProperty(Utils.PropOutlineScaledMaxDistance, properties);
             _outlineColor = FindProperty(Utils.PropOutlineColor, properties);
             _outlineLightingMix = FindProperty(Utils.PropOutlineLightingMix, properties);
-            _uvOffsetNormalTexture = FindProperty(Utils.PropUvOffsetNormalTexture, properties);
-            _uvOffsetNormalScale = FindProperty(Utils.PropUvOffsetNormalScale, properties);
             _uvAnimMaskTexture = FindProperty(Utils.PropUvAnimMaskTexture, properties);
             _uvAnimScrollX = FindProperty(Utils.PropUvAnimScrollX, properties);
             _uvAnimScrollY = FindProperty(Utils.PropUvAnimScrollY, properties);
@@ -316,14 +312,6 @@ namespace MToon
                     }
                     EditorGUILayout.Space();
 
-                    EditorGUILayout.LabelField("Offset Texture", EditorStyles.boldLabel);
-                    {
-                        materialEditor.TexturePropertySingleLine(new GUIContent("Offset [Normal]"),
-                            _uvOffsetNormalTexture,
-                            _uvOffsetNormalScale);
-                    }
-                    EditorGUILayout.Space();
-                    
                     EditorGUILayout.LabelField("Auto Animation", EditorStyles.boldLabel);
                     {
                         materialEditor.TexturePropertySingleLine(new GUIContent("Mask"), _uvAnimMaskTexture);

--- a/MToon/Resources/Shaders/MToon.shader
+++ b/MToon/Resources/Shaders/MToon.shader
@@ -30,8 +30,6 @@ Shader "VRM/MToon"
         _OutlineScaledMaxDistance ("Outline Scaled Max Distance", Range(1, 10)) = 1
         _OutlineColor ("Outline Color", Color) = (0,0,0,1)
         _OutlineLightingMix ("Outline Lighting Mix", Range(0, 1)) = 1
-        [Normal] _UvOffsetNormalTexture ("UV Offset Normal", 2D) = "bump" {}
-        _UvOffsetNormalScale ("Uv Offset Normal Scale", Float) = 1
         _UvAnimMaskTexture ("UV Animation Mask", 2D) = "white" {}
         _UvAnimScrollX ("UV Animation Scroll X", Float) = 0
         _UvAnimScrollY ("UV Animation Scroll Y", Float) = 0

--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -32,8 +32,6 @@ half _OutlineWidth;
 half _OutlineScaledMaxDistance;
 fixed4 _OutlineColor;
 half _OutlineLightingMix;
-sampler2D _UvOffsetNormalTexture;
-float _UvOffsetNormalScale;
 sampler2D _UvAnimMaskTexture;
 float _UvAnimScrollX;
 float _UvAnimScrollY;
@@ -123,9 +121,6 @@ float4 frag_forward(v2f i) : SV_TARGET
     
     // uv
     float2 mainUv = TRANSFORM_TEX(i.uv0, _MainTex);
-    
-    // offset uv with normal.xy*scale*0.01
-    mainUv += UnpackScaleNormal(tex2D(_UvOffsetNormalTexture, mainUv), _UvOffsetNormalScale * 0.01).xy;
     
     // uv anim
     half uvAnim = tex2D(_UvAnimMaskTexture, mainUv).r * _Time.y;

--- a/MToon/Scripts/MToonDefinition.cs
+++ b/MToon/Scripts/MToonDefinition.cs
@@ -101,8 +101,6 @@ namespace MToon
     {
         public Vector2 MainTextureLeftBottomOriginScale;
         public Vector2 MainTextureLeftBottomOriginOffset;
-        public Texture2D UvOffsetNormalTexture;
-        public float UvOffsetNormalScaleValue;
         public Texture2D UvAnimationMaskTexture;
         public float UvAnimationScrollXSpeedValue;
         public float UvAnimationScrollYSpeedValue;

--- a/MToon/Scripts/Utils.cs
+++ b/MToon/Scripts/Utils.cs
@@ -43,8 +43,6 @@ namespace MToon
         public const string PropOutlineScaledMaxDistance = "_OutlineScaledMaxDistance";
         public const string PropOutlineColor = "_OutlineColor";
         public const string PropOutlineLightingMix = "_OutlineLightingMix";
-        public const string PropUvOffsetNormalTexture = "_UvOffsetNormalTexture";
-        public const string PropUvOffsetNormalScale = "_UvOffsetNormalScale";
         public const string PropUvAnimMaskTexture = "_UvAnimMaskTexture";
         public const string PropUvAnimScrollX = "_UvAnimScrollX";
         public const string PropUvAnimScrollY = "_UvAnimScrollY";

--- a/MToon/Scripts/UtilsGetter.cs
+++ b/MToon/Scripts/UtilsGetter.cs
@@ -81,8 +81,6 @@ namespace MToon
                 {
                     MainTextureLeftBottomOriginScale = material.GetTextureScale(PropMainTex),
                     MainTextureLeftBottomOriginOffset = material.GetTextureOffset(PropMainTex),
-                    UvOffsetNormalTexture = GetTexture(material, PropUvOffsetNormalTexture),
-                    UvOffsetNormalScaleValue = GetValue(material, PropUvOffsetNormalScale),
                     UvAnimationMaskTexture = GetTexture(material, PropUvAnimMaskTexture),
                     UvAnimationScrollXSpeedValue = GetValue(material, PropUvAnimScrollX),
                     UvAnimationScrollYSpeedValue = GetValue(material, PropUvAnimScrollY),

--- a/MToon/Scripts/UtilsSetter.cs
+++ b/MToon/Scripts/UtilsSetter.cs
@@ -78,8 +78,6 @@ namespace MToon
                 var textureOptions = parameters.TextureOption;
                 material.SetTextureScale(PropMainTex, textureOptions.MainTextureLeftBottomOriginScale);
                 material.SetTextureOffset(PropMainTex, textureOptions.MainTextureLeftBottomOriginOffset);
-                material.SetTexture(PropUvOffsetNormalTexture, textureOptions.UvOffsetNormalTexture);
-                material.SetFloat(PropUvOffsetNormalScale, textureOptions.UvOffsetNormalScaleValue);
                 material.SetTexture(PropUvAnimMaskTexture, textureOptions.UvAnimationMaskTexture);
                 material.SetFloat(PropUvAnimScrollX, textureOptions.UvAnimationScrollXSpeedValue);
                 material.SetFloat(PropUvAnimScrollY, textureOptions.UvAnimationScrollYSpeedValue);


### PR DESCRIPTION
法線マッププロパティ以外への法線マップの使用が UniVRM の実装変更コストに与える影響が高いため