### PR TITLE
Set MToon Version when material created ignore opening inspector.

### DIFF
--- a/MToon/Resources/Shaders/MToon.shader
+++ b/MToon/Resources/Shaders/MToon.shader
@@ -35,7 +35,7 @@ Shader "VRM/MToon"
         _UvAnimScrollY ("UV Animation Scroll Y", Float) = 0
         _UvAnimRotation ("UV Animation Rotation", Float) = 0
 
-        [HideInInspector] _MToonVersion ("_MToonVersion", Float) = 0.0
+        [HideInInspector] _MToonVersion ("_MToonVersion", Float) = 30
         [HideInInspector] _DebugMode ("_DebugMode", Float) = 0.0
         [HideInInspector] _BlendMode ("_BlendMode", Float) = 0.0
         [HideInInspector] _OutlineWidthMode ("_OutlineWidthMode", Float) = 0.0


### PR DESCRIPTION
Material Inspector を介さずに `new Material(MToon.Utils.ShaderName)` したときに `_MToonVersion` を代入する