### PR TITLE
Ignore white out by main light + ambient light pass.

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -209,6 +209,8 @@ float4 frag_forward(v2f i) : SV_TARGET
     half3 indirectLighting = lerp(toonedGI, ShadeSH9(half4(worldNormal, 1)), _IndirectLightIntensity);
     indirectLighting = lerp(indirectLighting, max(EPS_COL, max(indirectLighting.x, max(indirectLighting.y, indirectLighting.z))), _LightColorAttenuation); // color atten
     col += indirectLighting * lit;
+    
+    col = min(col, lit); // comment out if you want to PBR absolutely.
 #endif
 
     // parametric rim lighting


### PR DESCRIPTION
For general use, Ignoring white out is desirable.
If you use exposure correction or eye adaptation with extremely strong or weak lights (e.g. HDRP), you may comment out this fix.