### PR TITLE
UV rotation UI improvement

### DIFF
--- a/MToon/Editor/MToonInspector.cs
+++ b/MToon/Editor/MToonInspector.cs
@@ -51,6 +51,9 @@ namespace MToon
         private MaterialProperty _uvAnimScrollY;
         private MaterialProperty _uvAnimRotation;
 
+        private MToon.RotationUnit uvRotationUnit = MToon.RotationUnit.Rounds ;
+        private float uvRotation;
+
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
         {
             _version = FindProperty(Utils.PropVersion, properties);
@@ -92,7 +95,7 @@ namespace MToon
             _uvAnimScrollX = FindProperty(Utils.PropUvAnimScrollX, properties);
             _uvAnimScrollY = FindProperty(Utils.PropUvAnimScrollY, properties);
             _uvAnimRotation = FindProperty(Utils.PropUvAnimRotation, properties);
-
+            uvRotation = getUvRotationValue(uvRotationUnit, _uvAnimRotation.floatValue);
             var materials = materialEditor.targets.Select(x => x as Material).ToArray();
             Draw(materialEditor, materials);
         }
@@ -317,7 +320,11 @@ namespace MToon
                         materialEditor.TexturePropertySingleLine(new GUIContent("Mask", "Auto Animation Mask Texture (R)"), _uvAnimMaskTexture);
                         materialEditor.ShaderProperty(_uvAnimScrollX, "Scroll X (per second)");
                         materialEditor.ShaderProperty(_uvAnimScrollY, "Scroll Y (per second)");
-                        materialEditor.ShaderProperty(_uvAnimRotation, "Rotation (per second)");
+                        uvRotationUnit = (MToon.RotationUnit)EditorGUILayout.EnumPopup("Rotation Unit", uvRotationUnit);
+                        uvRotation = EditorGUILayout.DelayedFloatField("Rotation value (per second)", uvRotation);
+                        _uvAnimRotation.floatValue = getUvRoundValue( uvRotationUnit, uvRotation);
+                        //materialEditor.ShaderProperty(_uvAnimRotation, "Rotation (per second)");
+             
                     }
                 }
                 EditorGUILayout.EndVertical();
@@ -400,6 +407,39 @@ namespace MToon
 #endif
                 showAlpha: false);
             
+        }
+
+        private float getUvRoundValue(MToon.RotationUnit unit , float val)
+        {
+            if (unit == MToon.RotationUnit.Rounds)
+            {
+                return val;
+            }
+            else if (unit == MToon.RotationUnit.Degrees)
+            {
+                return val / 360.0f;
+            }
+            else if (unit == MToon.RotationUnit.Radians)
+            {
+                return val / 2.0f;
+            }
+            return val;
+        }
+        private float getUvRotationValue(MToon.RotationUnit unit,float val)
+        {
+            if (unit == MToon.RotationUnit.Rounds)
+            {
+                return val;
+            }
+            else if (unit == MToon.RotationUnit.Degrees)
+            {
+                return val * 360.0f;
+            }
+            else if (unit == MToon.RotationUnit.Radians)
+            {
+                return val * 2.0f;
+            }
+            return val;
         }
     }
 }

--- a/MToon/Editor/MToonInspector.cs
+++ b/MToon/Editor/MToonInspector.cs
@@ -436,7 +436,7 @@ namespace MToon
                 }
                 case MToon.RotationUnit.Radians:
                 {
-                    return val / 2.0f;
+                    return val / (2.0f * 3.14159265359f);
                 }
                 default:
                     return val;
@@ -456,7 +456,7 @@ namespace MToon
                 }
                 case MToon.RotationUnit.Radians:
                 {
-                    return val * 2.0f;
+                    return val * (2.0f * 3.14159265359f);
                 }
                 default:
                     return val;

--- a/MToon/Editor/MToonInspector.cs
+++ b/MToon/Editor/MToonInspector.cs
@@ -9,6 +9,7 @@ namespace MToon
     public class MToonInspector : ShaderGUI
     {
         private static bool isAdvancedLightingPanelFoldout = false;
+        private static MToon.RotationUnit ofUvRotationUnit = MToon.RotationUnit.Rounds;
 
         private MaterialProperty _version;
         private MaterialProperty _blendMode;
@@ -51,9 +52,6 @@ namespace MToon
         private MaterialProperty _uvAnimScrollY;
         private MaterialProperty _uvAnimRotation;
 
-        private MToon.RotationUnit uvRotationUnit = MToon.RotationUnit.Rounds ;
-        private float uvRotation;
-
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
         {
             _version = FindProperty(Utils.PropVersion, properties);
@@ -95,7 +93,6 @@ namespace MToon
             _uvAnimScrollX = FindProperty(Utils.PropUvAnimScrollX, properties);
             _uvAnimScrollY = FindProperty(Utils.PropUvAnimScrollY, properties);
             _uvAnimRotation = FindProperty(Utils.PropUvAnimRotation, properties);
-            uvRotation = getUvRotationValue(uvRotationUnit, _uvAnimRotation.floatValue);
             var materials = materialEditor.targets.Select(x => x as Material).ToArray();
             Draw(materialEditor, materials);
         }
@@ -320,10 +317,26 @@ namespace MToon
                         materialEditor.TexturePropertySingleLine(new GUIContent("Mask", "Auto Animation Mask Texture (R)"), _uvAnimMaskTexture);
                         materialEditor.ShaderProperty(_uvAnimScrollX, "Scroll X (per second)");
                         materialEditor.ShaderProperty(_uvAnimScrollY, "Scroll Y (per second)");
-                        uvRotationUnit = (MToon.RotationUnit)EditorGUILayout.EnumPopup("Rotation Unit", uvRotationUnit);
+
+                        switch (EditorGUILayout.EnumPopup("Rotation Unit", ofUvRotationUnit))
+                        {
+                            case MToon.RotationUnit.Rounds:
+                                ofUvRotationUnit = MToon.RotationUnit.Rounds;
+                                break;
+                            case MToon.RotationUnit.Degrees:
+                                ofUvRotationUnit = MToon.RotationUnit.Degrees;
+                                break;
+                            case MToon.RotationUnit.Radians:
+                                ofUvRotationUnit = MToon.RotationUnit.Radians;
+                                break;
+                            default:
+                                ofUvRotationUnit = MToon.RotationUnit.Rounds;
+                                break;
+                        };
+                        var uvRotation = GetUvRotationValue(ofUvRotationUnit, _uvAnimRotation.floatValue);
+                        
                         uvRotation = EditorGUILayout.DelayedFloatField("Rotation value (per second)", uvRotation);
-                        _uvAnimRotation.floatValue = getUvRoundValue( uvRotationUnit, uvRotation);
-                        //materialEditor.ShaderProperty(_uvAnimRotation, "Rotation (per second)");
+                        _uvAnimRotation.floatValue = GetUvRoundValue(ofUvRotationUnit, uvRotation);
              
                     }
                 }
@@ -409,37 +422,45 @@ namespace MToon
             
         }
 
-        private float getUvRoundValue(MToon.RotationUnit unit , float val)
+        private float GetUvRoundValue(MToon.RotationUnit unit , float val)
         {
-            if (unit == MToon.RotationUnit.Rounds)
+            switch (unit)
             {
-                return val;
+                case MToon.RotationUnit.Rounds:
+                {
+                    return val;
+                }
+                case MToon.RotationUnit.Degrees:
+                {
+                    return val / 360.0f;
+                }
+                case MToon.RotationUnit.Radians:
+                {
+                    return val / 2.0f;
+                }
+                default:
+                    return val;
             }
-            else if (unit == MToon.RotationUnit.Degrees)
-            {
-                return val / 360.0f;
-            }
-            else if (unit == MToon.RotationUnit.Radians)
-            {
-                return val / 2.0f;
-            }
-            return val;
         }
-        private float getUvRotationValue(MToon.RotationUnit unit,float val)
+        private float GetUvRotationValue(MToon.RotationUnit unit,float val)
         {
-            if (unit == MToon.RotationUnit.Rounds)
+            switch (unit)
             {
-                return val;
+                case MToon.RotationUnit.Rounds:
+                {
+                    return val;
+                }
+                case MToon.RotationUnit.Degrees:
+                {
+                    return val * 360.0f;
+                }
+                case MToon.RotationUnit.Radians:
+                {
+                    return val * 2.0f;
+                }
+                default:
+                    return val;
             }
-            else if (unit == MToon.RotationUnit.Degrees)
-            {
-                return val * 360.0f;
-            }
-            else if (unit == MToon.RotationUnit.Radians)
-            {
-                return val * 2.0f;
-            }
-            return val;
         }
     }
 }

--- a/MToon/Scripts/Enums.cs
+++ b/MToon/Scripts/Enums.cs
@@ -35,6 +35,13 @@ namespace MToon
         Back = 2,
     }
 
+    public enum RotationUnit
+    {
+        Degrees = 0,
+        Radians = 1,
+        Rounds = 2
+    }
+
     public struct RenderQueueRequirement
     {
         public int DefaultValue;

--- a/MToon/Scripts/Enums.cs
+++ b/MToon/Scripts/Enums.cs
@@ -37,9 +37,9 @@ namespace MToon
 
     public enum RotationUnit
     {
-        Degrees = 0,
-        Radians = 1,
-        Rounds = 2
+        Rounds = 0,
+        Degrees = 1,
+        Radians = 2
     }
 
     public struct RenderQueueRequirement


### PR DESCRIPTION
about https://github.com/Santarh/MToon/issues/13#issuecomment-498727413
UI側で値をEnum単位に応じて変換してからシェーダに渡すようにしてみました。

既知の問題：単位を変換しても、UIの値がそれに追従しない。（360度/secｰ(回転に変更)->360回転/sec、になる。