### PR TITLE
Implements Alpha to Coverage.

### DIFF
--- a/MToon/Resources/Shaders/MToon.shader
+++ b/MToon/Resources/Shaders/MToon.shader
@@ -63,6 +63,7 @@ Shader "VRM/MToon"
             ZWrite [_ZWrite]
             ZTest LEqual
             BlendOp Add, Max
+            AlphaToMask On
 
             CGPROGRAM
             #pragma target 3.0
@@ -91,6 +92,7 @@ Shader "VRM/MToon"
             ZTest LEqual
             Offset 1, 1
             BlendOp Add, Max
+            AlphaToMask On
 
             CGPROGRAM
             #pragma target 3.0
@@ -121,6 +123,7 @@ Shader "VRM/MToon"
             ZWrite Off
             ZTest LEqual
             BlendOp Add, Max
+            AlphaToMask On
 
             CGPROGRAM
             #pragma target 3.0

--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -138,6 +138,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     half alpha = 1;
 #ifdef _ALPHATEST_ON
     alpha = _Color.a * mainTex.a;
+    alpha = (alpha - _Cutoff) / max(fwidth(alpha), EPS_COL) + 0.5; // Alpha to Coverage
     clip(alpha - _Cutoff);
 #endif
 #ifdef _ALPHABLEND_ON


### PR DESCRIPTION
From #80 

Implements Alpha to Coverage.
Considering MipMap is not implemented because VRM runtime importer usually does not generate MipMap and it has a little cost.