### PR TITLE
Fix strange alpha behaviour in cutout mode.

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -140,6 +140,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     alpha = _Color.a * mainTex.a;
     alpha = (alpha - _Cutoff) / max(fwidth(alpha), EPS_COL) + 0.5; // Alpha to Coverage
     clip(alpha - _Cutoff);
+    alpha = 1.0; // Discarded, otherwise it should be assumed to have full opacity
 #endif
 #ifdef _ALPHABLEND_ON
     alpha = _Color.a * mainTex.a;


### PR DESCRIPTION
Hi!

I am working on a face tracking application that captures the scene including the alpha channel. During this, I noticed some strange interactions with MToon's cutout mode:

* The alpha channel was not anti-aliased and the camera's clear color leaked into anti-aliased edge pixels for MToon cutout materials.
* Eyebrows using a MToon cutout material would create alpha holes in the face for semi-transparent pixels above the cutout threshold.

This very simple patch fixes both issues. Setting the alpha to 1.0 after `clip` should be fine. Pixels are already discarded if they are below the threshold. Otherwise, it should be safe to assume that they should be considered opaque. If blending should take place, the first line in the following `ifdef` block resets the alpha anyways.