### PR TITLE
Improve rendering of overlapping transparency

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -144,6 +144,9 @@ float4 frag_forward(v2f i) : SV_TARGET
 #endif
 #ifdef _ALPHABLEND_ON
     alpha = _Color.a * mainTex.a;
+#if !_ALPHATEST_ON && SHADER_API_D3D11 // Only enable this on D3D11, where I tested it
+    clip(alpha - 0.0001);              // Slightly improves rendering with layered transparency
+#endif
 #endif
     
     // normal


### PR DESCRIPTION
This patch adds clipping to rendering modes with alpha blending. Pixels that
are basically fully transparent are clipped, preventing fully transparent
meshes in front of other partially transparent meshes from cutting out
large parts of them. As a side effect, it might slightly improve
performance.

It's only enabled for D3D11, because I haven't tested it on other platforms.
I also mainly tested with TransparentWithZWrite. Before merging, more
tests might be necessary.

Without this patch, transparent meshes can cut other meshes like this:
![Original](https://user-images.githubusercontent.com/38952746/88668793-5cb8f400-d0e3-11ea-9884-8f3b9dd9c502.png)

With this, the effect is much less noticable:
![WithPatch](https://user-images.githubusercontent.com/38952746/88668831-6b9fa680-d0e3-11ea-8607-40e128b78c1e.png)
