### PR TITLE
Remove LICENSE and README meta in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,3 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
-
-# not Unity
-LICENSE.meta
-README.md.meta


### PR DESCRIPTION
変更前

LICENSE.meta と README.md.meta ファイルは存在しますが、.gitignoreの記述によってUniVRMShadersのUPMパッケージからは除外されます。
そのため、UniVRMShadersのUPMをレジストリからインポートしたプロジェクトでは次のエラーが出ます。

> Read only asset Packages/com.vrmc.vrmshaders/MToon/LICENSE has not meta file.
> Read only asset Packages/com.vrmc.vrmshaders/MToon/README.md has not meta file.

変更後

.gitignoreから.metaの記述を削除することにより、UPMレジストリにpublishするときに LICENSE.meta と README.md.meta ファイルも含まれるようになり、上記エラーは出なくなります。
また、Git URLによるインポートでは従来から LICENSE.meta と README.md.meta ファイルは含まれているため、インポート後の状態に変化はありません。