### PR TITLE
Add support for single pass instanced stereo rendering

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -53,13 +53,14 @@ struct v2f
     UNITY_FOG_COORDS(7)
     UNITY_SHADOW_COORDS(8)
     //UNITY_VERTEX_INPUT_INSTANCE_ID // necessary only if any instanced properties are going to be accessed in the fragment Shader.
+    UNITY_VERTEX_OUTPUT_STEREO 
 };
 
 inline v2f InitializeV2F(appdata_full v, float4 projectedVertex, float isOutline)
 {
     v2f o;
     UNITY_INITIALIZE_OUTPUT(v2f, o);
-    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     //UNITY_TRANSFER_INSTANCE_ID(v, o);
     
     o.pos = projectedVertex;
@@ -114,6 +115,7 @@ float4 frag_forward(v2f i) : SV_TARGET
 #endif
 
     //UNITY_TRANSFER_INSTANCE_ID(v, o);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
     
     // const
     const float PI_2 = 6.28318530718;

--- a/MToon/Resources/Shaders/MToonSM3.cginc
+++ b/MToon/Resources/Shaders/MToonSM3.cginc
@@ -2,18 +2,21 @@
 
 v2f vert_forward_base(appdata_full v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v.normal = normalize(v.normal);
     return InitializeV2F(v, UnityObjectToClipPos(v.vertex), 0);
 }
 
 v2f vert_forward_base_outline(appdata_full v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v.normal = normalize(v.normal);
     return InitializeV2F(v, CalculateOutlineVertexClipPosition(v), 1);
 }
 
 v2f vert_forward_add(appdata_full v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v.normal = normalize(v.normal);
     return InitializeV2F(v, UnityObjectToClipPos(v.vertex), 0);
 }

--- a/MToon/Resources/Shaders/MToonSM4.cginc
+++ b/MToon/Resources/Shaders/MToonSM4.cginc
@@ -2,12 +2,14 @@
 
 appdata_full vert_forward_base_with_outline(appdata_full v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v.normal = normalize(v.normal);
     return v;
 }
 
 v2f vert_forward_add(appdata_full v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v.normal = normalize(v.normal);
     return InitializeV2F(v, UnityObjectToClipPos(v.vertex), 0);
 }


### PR DESCRIPTION
Fixed an issue where the right eye was not rendered when rendering in Single Pass Instanced mode.

## Before
![image](https://user-images.githubusercontent.com/36906576/112602202-b7fbdb80-8e56-11eb-9276-e6a92df55749.png)

## After
![image](https://user-images.githubusercontent.com/36906576/112602279-ccd86f00-8e56-11eb-8602-b1b4f411219f.png)


Verified to work with Unity 2020.3.1f1 + OpenVR XR Plugin and Unity 2019.4.23f1 + OpenVR built-in XR.