### PR TITLE
Fix a bug that uv scroll is stuttering

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -32,7 +32,8 @@ half _OutlineWidth;
 half _OutlineScaledMaxDistance;
 fixed4 _OutlineColor;
 half _OutlineLightingMix;
-sampler2D _UvAnimMaskTexture;
+// NOTE: "tex2d() * _Time.y" returns mediump value if sampler is half precision in Android VR platform
+sampler2D_float _UvAnimMaskTexture;
 float _UvAnimScrollX;
 float _UvAnimScrollY;
 float _UvAnimRotation;


### PR DESCRIPTION
- `tex2d() * _Time.y` returns mediump value if sampler is half precision in Android VR platform
- Fix to use sampler2D_float