### PR TITLE
WorldCoordinatesのOutlineがOpaqueモードで動作しない不具合の修正

### DIFF
--- a/MToon/Resources/Shaders/MToonCore.cginc
+++ b/MToon/Resources/Shaders/MToonCore.cginc
@@ -1,6 +1,7 @@
 #ifndef MTOON_CORE_INCLUDED
 #define MTOON_CORE_INCLUDED
 
+#include "UnityGC.cginc"
 #include "Lighting.cginc"
 #include "AutoLight.cginc"
 


### PR DESCRIPTION
MTOON_OUTLINE_WIDTH_WORLDにはunity_WorldToObjectが使われているが、Opaqueモードだとincludeがされていないようだ
AlphaTestでは動作しているので、そちらはshaderファイル側でincludeしているのかもしれない（未調査なので重複するなら統合したい）